### PR TITLE
docs: add public community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to `dsalunga@live.com`. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of
+Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla-coc]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Wikitruth
+
+Thank you for helping improve Wikitruth. Contributions should make public
+knowledge easier to examine while preserving evidence, context, safety, and
+fairness.
+
+## Before You Start
+
+- Read the project `README.md` and the concise system contracts in
+  `docs/canonical/`.
+- Search existing issues and pull requests before proposing overlapping work.
+- Open an issue before a large architectural, data-model, governance, or user
+  experience change so the direction can be discussed first.
+- Report vulnerabilities privately according to `SECURITY.md`.
+
+## Development Setup
+
+Wikitruth supports Node.js 22 and 24. Use the version declared in `.nvmrc` when
+available.
+
+```bash
+npm ci
+npm run dev:all
+```
+
+Do not commit local `.env` files. Refer to
+`docs/frontend/ENVIRONMENT_VARIABLES.md` for configuration guidance and use
+synthetic data for local development and tests.
+
+## Contribution Workflow
+
+1. Fork the repository and create a focused branch.
+2. Make one coherent change at a time.
+3. Add or update tests for behavior changes.
+4. Run the relevant validation locally.
+5. Open a pull request targeting `develop` and explain the change, its impact,
+   and the checks you ran.
+
+`master` is the default release branch. Normal contributions should enter
+through `develop` rather than being pushed directly to `master`.
+
+## Validation
+
+At minimum, run the smoke checks and the tests relevant to your change:
+
+```bash
+npm run ci:smoke
+npm run test:server -- --runInBand
+npm run test:client -- --runInBand
+npm run build
+```
+
+The complete pull-request pipeline runs `npm run test:ci`. Browser-facing
+changes should also include appropriate Playwright, accessibility, or visual
+verification.
+
+## Contribution Standards
+
+- Use the project name **Wikitruth**.
+- Keep source files at or below 1,000 lines whenever practical.
+- Preserve API, URL, data, and legacy-compatibility contracts unless the pull
+  request explicitly changes an approved contract.
+- Keep public-interest claims source-attributed and distinguish evidence,
+  allegations, opinions, and outcomes.
+- Do not introduce reputation or guilt scores, inherited liability, harassment,
+  doxxing, or unnecessary personal data.
+- Never commit secrets, production exports, private records, or third-party
+  material that the project does not have permission to redistribute.
+- Keep generated files and unrelated formatting changes out of focused pull
+  requests.
+
+## Pull Requests
+
+A useful pull request includes:
+
+- what changed and why;
+- the user-visible and technical impact;
+- migration, compatibility, security, or rollback considerations;
+- screenshots for meaningful interface changes; and
+- the exact validation performed.
+
+Maintainers may ask for changes when a contribution conflicts with canonical
+system behavior, lacks evidence or tests, creates privacy or safety risks, or
+mixes unrelated work.
+
+## Licensing
+
+By submitting a contribution, you agree that it may be distributed under the
+repository's GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`).
+Only submit work you have the right to license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+Wikitruth welcomes responsible reports that help keep the project and its
+users safe.
+
+## Supported Versions
+
+Security fixes are prepared on the current `develop` branch and released
+through `master`. Only the current heads of those branches are supported.
+Older commits, forks, and privately maintained deployments may not receive
+security updates.
+
+## Reporting a Vulnerability
+
+Do not open a public issue or pull request for an undisclosed vulnerability.
+Instead, email `dsalunga@live.com` with:
+
+- a concise description of the vulnerability and its impact;
+- the affected version, commit, route, or component;
+- reproducible steps or a minimal proof of concept;
+- any suggested mitigation; and
+- whether the report or its details may be publicly credited after a fix.
+
+Do not access, alter, retain, or disclose data belonging to other people while
+investigating a potential vulnerability. Use synthetic data and the smallest
+safe proof necessary.
+
+The project will acknowledge a report as soon as practical, assess its scope,
+and coordinate remediation and disclosure with the reporter. Please allow a
+reasonable remediation window before publishing details.
+
+## Security Expectations for Contributions
+
+- Never commit credentials, secrets, private keys, production data, session
+  material, or personal data.
+- Use synthetic fixtures in tests and examples.
+- Keep authentication, authorization, validation, and tenant boundaries
+  fail-closed.
+- Include focused regression tests for security-sensitive changes.
+- Report dependency and supply-chain concerns through the same private channel
+  when public disclosure could put users at risk.


### PR DESCRIPTION
## What changed

- add a security policy with private reporting guidance
- add contribution setup, validation, safety, and licensing expectations
- adopt Contributor Covenant 2.1 as the project code of conduct

## Why

Wikitruth is now public and needs clear security-reporting and contributor-governance paths on its default branch.

## Checks

- `git diff --check`
- Gitleaks scan of `origin/develop..HEAD` (one commit, no leaks)
- verified referenced repository files and directories exist
- verified remote `develop` SHA matches local commit `8d406f7f17def91d47209cbe10f1d3be1ab3fffa`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Code of Conduct outlining community standards, reporting procedures, and enforcement.
  - Added contributor guidance covering setup, workflows, validation, pull requests, and licensing.
  - Added security guidance for reporting vulnerabilities, safe investigation, remediation, and disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->